### PR TITLE
Auto-return VFX and enemy VFX pooling

### DIFF
--- a/Assets/Prefabs/Enemy/Enemy_Death_VFX.prefab
+++ b/Assets/Prefabs/Enemy/Enemy_Death_VFX.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 5328190715540400666}
   - component: {fileID: 7169158956103086429}
   - component: {fileID: 4911162310073632652}
+  - component: {fileID: -8688076770861293969}
   m_Layer: 0
   m_Name: Enemy_Death_VFX
   m_TagString: Untagged
@@ -44,7 +45,7 @@ ParticleSystem:
   serializedVersion: 8
   lengthInSec: 1
   simulationSpeed: 1
-  stopAction: 1
+  stopAction: 0
   cullingMode: 0
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
@@ -4907,3 +4908,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2add67b6f0c34b0b91db5d989715ef45, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::TowerDefense.Core.ObjectToPool
+--- !u!114 &-8688076770861293969
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3195599145901544641}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c0dceeb14a145309491689a1fe53293, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::TowerDefense.Core.VFXAutoReturn

--- a/Assets/Scripts/Core/Pooling/VFXAutoReturn.cs
+++ b/Assets/Scripts/Core/Pooling/VFXAutoReturn.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+namespace TowerDefense.Core
+{
+    /// <summary>
+    /// Attach to any VFX prefab that lives in a pool.
+    /// Automatically returns to pool when the particle system finishes.
+    /// </summary>
+    [RequireComponent(typeof(ParticleSystem))]
+    public class VFXAutoReturn : MonoBehaviour
+    {
+        private ParticleSystem _particles;
+        private ObjectToPool _poolObject;
+
+        private void Awake()
+        {
+            _particles  = GetComponent<ParticleSystem>();
+            _poolObject = GetComponent<ObjectToPool>();
+        }
+
+        private void OnEnable()
+        {
+            // Play On Awake handles playback — just wait for it to finish
+            _particles.Play();
+        }
+
+        private void Update()
+        {
+            if (!_particles.IsAlive())
+                ReturnToPool();
+        }
+
+        private void ReturnToPool()
+        {
+            if (_poolObject != null)
+                _poolObject.ReturnToPool();
+            else
+                gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Pooling/VFXAutoReturn.cs.meta
+++ b/Assets/Scripts/Core/Pooling/VFXAutoReturn.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7c0dceeb14a145309491689a1fe53293
+timeCreated: 1775114833

--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -24,11 +24,11 @@ namespace TowerDefense.Enemies
 
         public void Initialize(EnemyData data, Transform target)
         {
-            Data    = data;
+            Data = data;
             _target = target;
 
-            _currentHealth   = data.maxHealth;
-            _spriteRenderer  = GetComponentInChildren<SpriteRenderer>();
+            _currentHealth = data.maxHealth;
+            _spriteRenderer = GetComponentInChildren<SpriteRenderer>();
 
             if (_spriteRenderer != null)
                 _originalColor = _spriteRenderer.color;
@@ -92,41 +92,30 @@ namespace TowerDefense.Enemies
             {
                 var vfx = PoolManager.Instance.Get("DeathVFX");
                 if (vfx != null)
-                {
                     vfx.transform.position = transform.position;
-                    // Auto-return after clip length
-                    StartCoroutine(ReturnVFXToPool(vfx, 2f));
-                }
+                // VFXAutoReturn component handles returning to pool
             }
 
             GameManager.Instance?.RegisterKill(Data.scoreValue);
             OnDeath?.Invoke(this);
-
-            // Return to pool instead of Destroy
             GetComponent<ObjectToPool>()?.ReturnToPool();
         }
 
-        private System.Collections.IEnumerator ReturnVFXToPool(ObjectToPool vfx, float delay)
-        {
-            yield return new WaitForSeconds(delay);
-            vfx.ReturnToPool();
-        }
-
-// Called by EnemySpawner after Get() to reset state
+        // Called by EnemySpawner after Get() to reset state
         public void ResetState(EnemyData data, Transform target)
         {
-            IsDead         = false;
-            Data           = data;
-            _target        = target;
+            IsDead = false;
+            Data = data;
+            _target = target;
             _currentHealth = data.maxHealth;
 
 
             if (_spriteRenderer == null)
             {
-                _spriteRenderer  = GetComponentInChildren<SpriteRenderer>();
+                _spriteRenderer = GetComponentInChildren<SpriteRenderer>();
                 _originalColor = _spriteRenderer.color;
             }
-                
+
             _spriteRenderer.color = _originalColor;
         }
 
@@ -135,14 +124,12 @@ namespace TowerDefense.Enemies
         private void OnTriggerEnter2D(Collider2D other)
         {
             if (!other.CompareTag("Player")) return;
-            
+
             var target = other.GetComponent<IDamageable>();
             if (target == null || target.IsDead) return;
 
             target.TakeDamage(Data.damage);
             Die();
         }
-
-        
     }
 }


### PR DESCRIPTION
Add VFXAutoReturn component and wire it into death VFX prefab, enabling particle-driven auto-return to pool. Update Enemy to spawn pooled DeathVFX without a manual coroutine and rely on VFXAutoReturn (or fallback to disabling) to return the effect. Clean up minor formatting and remove the obsolete ReturnVFXToPool coroutine. Also adjust ParticleSystem stopAction on the prefab and add the new script's meta file.